### PR TITLE
Feature/transfer long operations

### DIFF
--- a/products/ASC.Files/Core/Core/FileStorageService.cs
+++ b/products/ASC.Files/Core/Core/FileStorageService.cs
@@ -2103,23 +2103,6 @@ public class FileStorageService //: IFileStorageService
 
         return result;
     }
-    public async Task<List<FileOperationResult>> MoveOrCopyItemsAsync(List<string> fileStringIds, List<string> folderStringIds, List<int> fileIntIds, List<int> folderIntIds, JsonElement destFolderId, FileConflictResolveType resolve, bool ic, bool deleteAfter = false, bool content = false)
-    {
-        ErrorIf(resolve == FileConflictResolveType.Overwrite && await _userManager.IsUserAsync(_authContext.CurrentAccount.ID), FilesCommonResource.ErrorMassage_SecurityException);
-
-        List<FileOperationResult> result;
-        if (fileStringIds != null || folderStringIds != null || fileIntIds != null || folderIntIds != null)
-        {
-            result = await _fileOperationsManager.MoveOrCopy(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), folderStringIds, fileStringIds, folderIntIds, fileIntIds, destFolderId, ic, resolve,
-                !deleteAfter, GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync(), content);
-        }
-        else
-        {
-            result = _fileOperationsManager.GetOperationResults(_authContext.CurrentAccount.ID);
-        }
-
-        return result;
-    }
 
     public async Task<List<FileOperationResult>> DeleteFileAsync<T>(string action, T fileId, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
     {
@@ -2132,9 +2115,9 @@ public class FileStorageService //: IFileStorageService
             !deleteAfter, immediately, GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync());
     }
 
-    public async Task<List<FileOperationResult>> DeleteItemsAsync(string action, List<string> fileStringIds, List<string> folderStringIds, List<int> fileIntIds, List<int> folderIntIds, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
+    public async Task<List<FileOperationResult>> DeleteItemsAsync(string action, List<JsonElement> files, List<JsonElement> folders, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
     {
-        return _fileOperationsManager.Delete(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), folderStringIds, fileStringIds, folderIntIds, fileIntIds, ignoreException, !deleteAfter, immediately,
+        return _fileOperationsManager.Delete(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), folders, files, ignoreException, !deleteAfter, immediately,
             GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync());
     }
 

--- a/products/ASC.Files/Core/Core/FileStorageService.cs
+++ b/products/ASC.Files/Core/Core/FileStorageService.cs
@@ -2103,6 +2103,23 @@ public class FileStorageService //: IFileStorageService
 
         return result;
     }
+    public async Task<List<FileOperationResult>> MoveOrCopyItemsAsync(List<string> fileStringIds, List<string> folderStringIds, List<int> fileIntIds, List<int> folderIntIds, JsonElement destFolderId, FileConflictResolveType resolve, bool ic, bool deleteAfter = false, bool content = false)
+    {
+        ErrorIf(resolve == FileConflictResolveType.Overwrite && await _userManager.IsUserAsync(_authContext.CurrentAccount.ID), FilesCommonResource.ErrorMassage_SecurityException);
+
+        List<FileOperationResult> result;
+        if (fileStringIds != null || folderStringIds != null || fileIntIds != null || folderIntIds != null)
+        {
+            result = await _fileOperationsManager.MoveOrCopy(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), folderStringIds, fileStringIds, folderIntIds, fileIntIds, destFolderId, ic, resolve,
+                !deleteAfter, GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync(), content);
+        }
+        else
+        {
+            result = _fileOperationsManager.GetOperationResults(_authContext.CurrentAccount.ID);
+        }
+
+        return result;
+    }
 
     public async Task<List<FileOperationResult>> DeleteFileAsync<T>(string action, T fileId, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
     {
@@ -2115,9 +2132,9 @@ public class FileStorageService //: IFileStorageService
             !deleteAfter, immediately, GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync());
     }
 
-    public async Task<List<FileOperationResult>> DeleteItemsAsync(string action, List<JsonElement> files, List<JsonElement> folders, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
+    public async Task<List<FileOperationResult>> DeleteItemsAsync(string action, List<string> fileStringIds, List<string> folderStringIds, List<int> fileIntIds, List<int> folderIntIds, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
     {
-        return _fileOperationsManager.Delete(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), folders, files, ignoreException, !deleteAfter, immediately,
+        return _fileOperationsManager.Delete(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), folderStringIds, fileStringIds, folderIntIds, fileIntIds, ignoreException, !deleteAfter, immediately,
             GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync());
     }
 

--- a/products/ASC.Files/Core/Core/FileStorageService.cs
+++ b/products/ASC.Files/Core/Core/FileStorageService.cs
@@ -1677,6 +1677,16 @@ public class FileStorageService //: IFileStorageService
         return _fileOperationsManager.MarkAsRead(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), foldersId, filesId, GetHttpHeaders(),
             await _externalShare.GetCurrentShareDataAsync());
     }
+    public async Task<List<FileOperationResult>> MarkAsReadAsync(List<string> foldersIdString, List<string> filesIdString, List<int> foldersIdInt, List<int> filesIdInt)
+    {
+        if (foldersIdString == null && filesIdString == null && foldersIdInt == null && filesIdInt == null)
+        {
+            return GetTasksStatuses();
+        }
+
+        return _fileOperationsManager.MarkAsRead(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), foldersIdString, filesIdString, foldersIdInt, filesIdInt,  GetHttpHeaders(),
+            await _externalShare.GetCurrentShareDataAsync());
+    }
 
     public IAsyncEnumerable<ThirdPartyParams> GetThirdPartyAsync()
     {
@@ -2104,6 +2114,24 @@ public class FileStorageService //: IFileStorageService
         return result;
     }
 
+    public async Task<List<FileOperationResult>> MoveOrCopyItemsAsync(List<string> foldersIdString, List<string> filesIdString, List<int> foldersIdInt, List<int> filesIdInt, JsonElement destFolderId, FileConflictResolveType resolve, bool ic, bool deleteAfter = false, bool content = false)
+    {
+        ErrorIf(resolve == FileConflictResolveType.Overwrite && await _userManager.IsUserAsync(_authContext.CurrentAccount.ID), FilesCommonResource.ErrorMassage_SecurityException);
+
+        List<FileOperationResult> result;
+        if (filesIdString != null || foldersIdString != null || filesIdInt != null || foldersIdInt != null)
+        {
+            result = await _fileOperationsManager.MoveOrCopy(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), foldersIdString, filesIdString, foldersIdInt, filesIdInt, destFolderId, ic, resolve,
+                !deleteAfter, GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync(), content);
+        }
+        else
+        {
+            result = _fileOperationsManager.GetOperationResults(_authContext.CurrentAccount.ID);
+        }
+
+        return result;
+    }
+
     public async Task<List<FileOperationResult>> DeleteFileAsync<T>(string action, T fileId, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
     {
         return _fileOperationsManager.Delete(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), new List<T>(), new List<T>() { fileId }, ignoreException,
@@ -2118,6 +2146,11 @@ public class FileStorageService //: IFileStorageService
     public async Task<List<FileOperationResult>> DeleteItemsAsync(string action, List<JsonElement> files, List<JsonElement> folders, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
     {
         return _fileOperationsManager.Delete(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), folders, files, ignoreException, !deleteAfter, immediately,
+            GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync());
+    }
+    public async Task<List<FileOperationResult>> DeleteItemsAsync(string action, List<string> foldersIdString, List<string> filesIdString, List<int> foldersIdInt, List<int> filesIdInt, bool ignoreException = false, bool deleteAfter = false, bool immediately = false)
+    {
+        return _fileOperationsManager.Delete(_authContext.CurrentAccount.ID, await _tenantManager.GetCurrentTenantAsync(), foldersIdString, filesIdString, foldersIdInt, filesIdInt, ignoreException, !deleteAfter, immediately,
             GetHttpHeaders(), await _externalShare.GetCurrentShareDataAsync());
     }
 

--- a/products/ASC.Files/Core/IntegrationEvents/Events/BulkDownloadIntegrationEvent.cs
+++ b/products/ASC.Files/Core/IntegrationEvents/Events/BulkDownloadIntegrationEvent.cs
@@ -27,32 +27,17 @@
 namespace ASC.Files.Core.IntegrationEvents.Events;
 
 [ProtoContract]
-public record MoveOrCopyIntegrationEvent : IntegrationEvent
+public record BulkDownloadIntegrationEvent : IntegrationEvent
 {
-    private MoveOrCopyIntegrationEvent() : base() { }
-    public MoveOrCopyIntegrationEvent(Guid createBy, int tenantId) : base(createBy, tenantId)
+    private BulkDownloadIntegrationEvent() : base() { }
+    public BulkDownloadIntegrationEvent(Guid createBy, int tenantId) : base(createBy, tenantId)
     {
 
     }
 
     [ProtoMember(1)]
-    public bool DeleteAfter { get; set; }
+    public Dictionary<string, string> FolderIdsString { get; set; }
 
-    [ProtoMember(2)]
-    public bool Ic { get; set; }
-
-    [ProtoMember(3)]
-    public List<string> FolderIdsString { get; set; }
-
-    [ProtoMember(4)]
-    public List<string> FileIdsString { get; set; }
-
-    [ProtoMember(5)]
-    public bool Content { get; set; }
-
-    [ProtoMember(6)]
-    public FileConflictResolveType ConflictResolveType { get; set; }
-
-    [ProtoMember(7)]
-    public string DestFolderId { get; set; }
+    [ProtoMember(2)] 
+    public Dictionary<string, string> FileIdsString { get; set; }
 }

--- a/products/ASC.Files/Core/IntegrationEvents/Events/DeleteIntegrationEvent.cs
+++ b/products/ASC.Files/Core/IntegrationEvents/Events/DeleteIntegrationEvent.cs
@@ -1,0 +1,56 @@
+﻿// (c) Copyright Ascensio System SIA 2010-2022
+//
+// This program is a free software product.
+// You can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License (AGPL) version 3 as published by the Free Software
+// Foundation. In accordance with Section 7(a) of the GNU AGPL its Section 15 shall be amended
+// to the effect that Ascensio System SIA expressly excludes the warranty of non-infringement of
+// any third-party rights.
+//
+// This program is distributed WITHOUT ANY WARRANTY, without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For details, see
+// the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+//
+// You can contact Ascensio System SIA at Lubanas st. 125a-25, Riga, Latvia, EU, LV-1021.
+//
+// The  interactive user interfaces in modified source and object code versions of the Program must
+// display Appropriate Legal Notices, as required under Section 5 of the GNU AGPL version 3.
+//
+// Pursuant to Section 7(b) of the License you must retain the original Product logo when
+// distributing the program. Pursuant to Section 7(e) we decline to grant you any rights under
+// trademark law for use of our trademarks.
+//
+// All the Product's GUI elements, including illustrations and icon sets, as well as technical writing
+// content are licensed under the terms of the Creative Commons Attribution-ShareAlike 4.0
+// International. See the License terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+
+namespace ASC.Files.Core.IntegrationEvents.Events;
+
+[ProtoContract]
+public record DeleteIntegrationEvent : IntegrationEvent
+{
+    private DeleteIntegrationEvent() : base() { }
+    public  DeleteIntegrationEvent(Guid createBy, int tenantId) : base(createBy, tenantId)
+    {
+
+    }
+
+    [ProtoMember(1)]
+    public bool DeleteAfter { get; set; }
+
+    [ProtoMember(2)]
+    public bool Immediately { get; set; }
+
+    [ProtoMember(3)]
+    public List<string> FolderIdsString { get; set; }
+
+    [ProtoMember(4)]
+    public List<string> FileIdsString { get; set; }
+    [ProtoMember(5)]
+    public List<int> FolderIds { get; set; }
+
+    [ProtoMember(6)]
+    public List<int> FileIds { get; set; }
+
+
+}

--- a/products/ASC.Files/Core/IntegrationEvents/Events/DeleteIntegrationEvent.cs
+++ b/products/ASC.Files/Core/IntegrationEvents/Events/DeleteIntegrationEvent.cs
@@ -46,4 +46,10 @@ public record DeleteIntegrationEvent : IntegrationEvent
 
     [ProtoMember(4)]
     public List<string> FileIdsString { get; set; }
+
+    [ProtoMember(5)]
+    public List<int> FolderIdsInt { get; set; }
+
+    [ProtoMember(6)]
+    public List<int> FileIdsInt { get; set; }
 }

--- a/products/ASC.Files/Core/IntegrationEvents/Events/DeleteIntegrationEvent.cs
+++ b/products/ASC.Files/Core/IntegrationEvents/Events/DeleteIntegrationEvent.cs
@@ -46,11 +46,4 @@ public record DeleteIntegrationEvent : IntegrationEvent
 
     [ProtoMember(4)]
     public List<string> FileIdsString { get; set; }
-    [ProtoMember(5)]
-    public List<int> FolderIds { get; set; }
-
-    [ProtoMember(6)]
-    public List<int> FileIds { get; set; }
-
-
 }

--- a/products/ASC.Files/Core/IntegrationEvents/Events/EmptyTrashIntegrationEvent.cs
+++ b/products/ASC.Files/Core/IntegrationEvents/Events/EmptyTrashIntegrationEvent.cs
@@ -27,36 +27,11 @@
 namespace ASC.Files.Core.IntegrationEvents.Events;
 
 [ProtoContract]
-public record MoveOrCopyIntegrationEvent : IntegrationEvent
+public record EmptyTrashIntegrationEvent : IntegrationEvent
 {
-    private MoveOrCopyIntegrationEvent() : base() { }
-    public MoveOrCopyIntegrationEvent(Guid createBy, int tenantId) : base(createBy, tenantId)
+    private EmptyTrashIntegrationEvent() : base() { }
+    public EmptyTrashIntegrationEvent(Guid createBy, int tenantId) : base(createBy, tenantId)
     {
 
     }
-
-    [ProtoMember(1)]
-    public bool DeleteAfter { get; set; }
-
-    [ProtoMember(2)]
-    public bool Ic { get; set; }
-
-    [ProtoMember(3)]
-    public List<string> FolderIdsString { get; set; }
-
-    [ProtoMember(4)]
-    public List<string> FileIdsString { get; set; }
-    [ProtoMember(5)]
-    public List<int> FolderIdsInt { get; set; }
-    [ProtoMember(6)]
-    public List<int> FileIdsInt { get; set; }
-
-    [ProtoMember(7)]
-    public bool Content { get; set; }
-
-    [ProtoMember(8)]
-    public FileConflictResolveType ConflictResolveType { get; set; }
-
-    [ProtoMember(9)]
-    public string DestFolderId { get; set; }
 }

--- a/products/ASC.Files/Core/IntegrationEvents/Events/MarkAsReadIntegrationEvent.cs
+++ b/products/ASC.Files/Core/IntegrationEvents/Events/MarkAsReadIntegrationEvent.cs
@@ -27,36 +27,21 @@
 namespace ASC.Files.Core.IntegrationEvents.Events;
 
 [ProtoContract]
-public record MoveOrCopyIntegrationEvent : IntegrationEvent
+public record MarkAsReadIntegrationEvent : IntegrationEvent
 {
-    private MoveOrCopyIntegrationEvent() : base() { }
-    public MoveOrCopyIntegrationEvent(Guid createBy, int tenantId) : base(createBy, tenantId)
+    private MarkAsReadIntegrationEvent() : base() { }
+    public MarkAsReadIntegrationEvent(Guid createBy, int tenantId) : base(createBy, tenantId)
     {
 
     }
 
     [ProtoMember(1)]
-    public bool DeleteAfter { get; set; }
-
-    [ProtoMember(2)]
-    public bool Ic { get; set; }
-
-    [ProtoMember(3)]
     public List<string> FolderIdsString { get; set; }
 
-    [ProtoMember(4)]
+    [ProtoMember(2)] 
     public List<string> FileIdsString { get; set; }
-    [ProtoMember(5)]
+    [ProtoMember(3)]
     public List<int> FolderIdsInt { get; set; }
-    [ProtoMember(6)]
+    [ProtoMember(4)]
     public List<int> FileIdsInt { get; set; }
-
-    [ProtoMember(7)]
-    public bool Content { get; set; }
-
-    [ProtoMember(8)]
-    public FileConflictResolveType ConflictResolveType { get; set; }
-
-    [ProtoMember(9)]
-    public string DestFolderId { get; set; }
 }

--- a/products/ASC.Files/Core/IntegrationEvents/Events/MoveOrCopyIntegrationEvent.cs
+++ b/products/ASC.Files/Core/IntegrationEvents/Events/MoveOrCopyIntegrationEvent.cs
@@ -1,0 +1,63 @@
+﻿// (c) Copyright Ascensio System SIA 2010-2022
+//
+// This program is a free software product.
+// You can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License (AGPL) version 3 as published by the Free Software
+// Foundation. In accordance with Section 7(a) of the GNU AGPL its Section 15 shall be amended
+// to the effect that Ascensio System SIA expressly excludes the warranty of non-infringement of
+// any third-party rights.
+//
+// This program is distributed WITHOUT ANY WARRANTY, without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For details, see
+// the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+//
+// You can contact Ascensio System SIA at Lubanas st. 125a-25, Riga, Latvia, EU, LV-1021.
+//
+// The  interactive user interfaces in modified source and object code versions of the Program must
+// display Appropriate Legal Notices, as required under Section 5 of the GNU AGPL version 3.
+//
+// Pursuant to Section 7(b) of the License you must retain the original Product logo when
+// distributing the program. Pursuant to Section 7(e) we decline to grant you any rights under
+// trademark law for use of our trademarks.
+//
+// All the Product's GUI elements, including illustrations and icon sets, as well as technical writing
+// content are licensed under the terms of the Creative Commons Attribution-ShareAlike 4.0
+// International. See the License terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+
+namespace ASC.Files.Core.IntegrationEvents.Events;
+
+[ProtoContract]
+public record MoveOrCopyIntegrationEvent : IntegrationEvent
+{
+    private MoveOrCopyIntegrationEvent() : base() { }
+    public MoveOrCopyIntegrationEvent(Guid createBy, int tenantId) : base(createBy, tenantId)
+    {
+
+    }
+
+    [ProtoMember(1)]
+    public bool DeleteAfter { get; set; }
+
+    [ProtoMember(2)]
+    public bool Ic { get; set; }
+
+    [ProtoMember(3)]
+    public List<string> FolderIdsString { get; set; }
+
+    [ProtoMember(4)]
+    public List<string> FileIdsString { get; set; }
+    [ProtoMember(5)]
+    public List<int> FolderIds { get; set; }
+
+    [ProtoMember(6)]
+    public List<int> FileIds { get; set; }
+
+    [ProtoMember(7)]
+    public bool Content { get; set; }
+
+    [ProtoMember(8)]
+    public FileConflictResolveType ConflictResolveType { get; set; }
+
+    [ProtoMember(9)]
+    public string DestFolderId { get; set; }
+}

--- a/products/ASC.Files/Core/Services/WCFService/FileOperations/FileOperationsManager.cs
+++ b/products/ASC.Files/Core/Services/WCFService/FileOperations/FileOperationsManager.cs
@@ -213,9 +213,11 @@ public class FileOperationsManager
         return QueueTask(userId, op);
     }
 
-    public List<FileOperationResult> Delete(Guid userId, Tenant tenant, List<string> folderStringIds, List<string> fileStringIds, List<int> folderIntIds, List<int> fileIntIds, bool ignoreException, bool holdResult, bool immediately, IDictionary<string, StringValues> headers,
+    public List<FileOperationResult> Delete(Guid userId, Tenant tenant, List<JsonElement> folders, List<JsonElement> files, bool ignoreException, bool holdResult, bool immediately, IDictionary<string, StringValues> headers,
         ExternalShareData externalShareData, bool isEmptyTrash = false)
     {
+        var (folderIntIds, folderStringIds) = GetIds(folders);
+        var (fileIntIds, fileStringIds) = GetIds(files);
 
         var op1 = new FileDeleteOperation<int>(_serviceProvider, new FileDeleteOperationData<int>(folderIntIds, fileIntIds, tenant, externalShareData, holdResult, ignoreException, immediately, headers, isEmptyTrash), _thumbnailSettings);
         var op2 = new FileDeleteOperation<string>(_serviceProvider, new FileDeleteOperationData<string>(folderStringIds, fileStringIds, tenant, externalShareData, holdResult, ignoreException, immediately, headers, isEmptyTrash), _thumbnailSettings);

--- a/products/ASC.Files/Core/Services/WCFService/FileOperations/FileOperationsManager.cs
+++ b/products/ASC.Files/Core/Services/WCFService/FileOperations/FileOperationsManager.cs
@@ -116,7 +116,15 @@ public class FileOperationsManager
 
         return QueueTask(userId, op);
     }
+    public List<FileOperationResult> MarkAsRead(Guid userId, Tenant tenant, List<string> folderIdsString, List<string> fileIdsString, List<int> folderIdsInt, List<int> fileIdsInt, IDictionary<string, StringValues> headers,
+        ExternalShareData externalShareData)
+    {
+        var op1 = new FileMarkAsReadOperation<int>(_serviceProvider, new FileMarkAsReadOperationData<int>(folderIdsInt, fileIdsInt, tenant, headers, externalShareData));
+        var op2 = new FileMarkAsReadOperation<string>(_serviceProvider, new FileMarkAsReadOperationData<string>(folderIdsString, fileIdsString, tenant, headers, externalShareData));
+        var op = new FileMarkAsReadOperation(_serviceProvider, op2, op1);
 
+        return QueueTask(userId, op);
+    }
     public List<FileOperationResult> Download(Guid userId, Tenant tenant, Dictionary<JsonElement, string> folders, Dictionary<JsonElement, string> files, IDictionary<string, StringValues> headers,
         ExternalShareData externalShareData)
     {
@@ -226,7 +234,15 @@ public class FileOperationsManager
         return QueueTask(userId, op);
     }
 
+    public List<FileOperationResult> Delete(Guid userId, Tenant tenant, List<string> foldersIdString, List<string> filesIdString, List<int> foldersIdInt, List<int> filesIdInt, bool ignoreException, bool holdResult, bool immediately, IDictionary<string, StringValues> headers,
+        ExternalShareData externalShareData, bool isEmptyTrash = false)
+    {
+        var op1 = new FileDeleteOperation<int>(_serviceProvider, new FileDeleteOperationData<int>(foldersIdInt, filesIdInt, tenant, externalShareData, holdResult, ignoreException, immediately, headers, isEmptyTrash), _thumbnailSettings);
+        var op2 = new FileDeleteOperation<string>(_serviceProvider, new FileDeleteOperationData<string>(foldersIdString, filesIdString, tenant, externalShareData, holdResult, ignoreException, immediately, headers, isEmptyTrash), _thumbnailSettings);
+        var op = new FileDeleteOperation(_serviceProvider, op2, op1);
 
+        return QueueTask(userId, op);
+    }
     private List<FileOperationResult> QueueTask(Guid userId, DistributedTaskProgress op)
     {
         _tasks.EnqueueTask(op);

--- a/products/ASC.Files/Service/Program.cs
+++ b/products/ASC.Files/Service/Program.cs
@@ -71,6 +71,8 @@ try
     eventBus.Subscribe<DeleteIntegrationEvent, DeleteIntegrationEventHandler>();
     eventBus.Subscribe<MoveOrCopyIntegrationEvent, MoveOrCopyIntegrationEventHandler>();
     eventBus.Subscribe<BulkDownloadIntegrationEvent, BulkDownloadIntegrationEventHandler>();
+    eventBus.Subscribe<MarkAsReadIntegrationEvent, MarkAsReadIntegrationEventHandler>();
+    eventBus.Subscribe<EmptyTrashIntegrationEvent, EmptyTrashIntegrationEventHandler>();
 
     logger.Info("Starting web host ({applicationContext})...", AppName);
     await app.RunWithTasksAsync();

--- a/products/ASC.Files/Service/Program.cs
+++ b/products/ASC.Files/Service/Program.cs
@@ -68,6 +68,8 @@ try
     var eventBus = ((IApplicationBuilder)app).ApplicationServices.GetRequiredService<IEventBus>();
 
     eventBus.Subscribe<ThumbnailRequestedIntegrationEvent, ThumbnailRequestedIntegrationEventHandler>();
+    eventBus.Subscribe<DeleteIntegrationEvent, DeleteIntegrationEventHandler>();
+    eventBus.Subscribe<MoveOrCopyIntegrationEvent, MoveOrCopyIntegrationEventHandler>();
 
     logger.Info("Starting web host ({applicationContext})...", AppName);
     await app.RunWithTasksAsync();

--- a/products/ASC.Files/Service/Program.cs
+++ b/products/ASC.Files/Service/Program.cs
@@ -70,6 +70,7 @@ try
     eventBus.Subscribe<ThumbnailRequestedIntegrationEvent, ThumbnailRequestedIntegrationEventHandler>();
     eventBus.Subscribe<DeleteIntegrationEvent, DeleteIntegrationEventHandler>();
     eventBus.Subscribe<MoveOrCopyIntegrationEvent, MoveOrCopyIntegrationEventHandler>();
+    eventBus.Subscribe<BulkDownloadIntegrationEvent, BulkDownloadIntegrationEventHandler>();
 
     logger.Info("Starting web host ({applicationContext})...", AppName);
     await app.RunWithTasksAsync();

--- a/products/ASC.Files/Service/Startup.cs
+++ b/products/ASC.Files/Service/Startup.cs
@@ -79,6 +79,8 @@ public class Startup : BaseWorkerStartup
         DIHelper.TryAdd<DeleteIntegrationEventHandler>();
         DIHelper.TryAdd<MoveOrCopyIntegrationEventHandler>();
         DIHelper.TryAdd<BulkDownloadIntegrationEventHandler>();
+        DIHelper.TryAdd<MarkAsReadIntegrationEventHandler>();
+        DIHelper.TryAdd<EmptyTrashIntegrationEventHandler>();
 
         services.AddHostedService<Launcher>();
         DIHelper.TryAdd<Launcher>();

--- a/products/ASC.Files/Service/Startup.cs
+++ b/products/ASC.Files/Service/Startup.cs
@@ -76,6 +76,8 @@ public class Startup : BaseWorkerStartup
         DIHelper.TryAdd<ThumbnailBuilderService>();
 
         DIHelper.TryAdd<ThumbnailRequestedIntegrationEventHandler>();
+        DIHelper.TryAdd<DeleteIntegrationEventHandler>();
+        DIHelper.TryAdd<MoveOrCopyIntegrationEventHandler>();
 
         services.AddHostedService<Launcher>();
         DIHelper.TryAdd<Launcher>();

--- a/products/ASC.Files/Service/Startup.cs
+++ b/products/ASC.Files/Service/Startup.cs
@@ -78,6 +78,7 @@ public class Startup : BaseWorkerStartup
         DIHelper.TryAdd<ThumbnailRequestedIntegrationEventHandler>();
         DIHelper.TryAdd<DeleteIntegrationEventHandler>();
         DIHelper.TryAdd<MoveOrCopyIntegrationEventHandler>();
+        DIHelper.TryAdd<BulkDownloadIntegrationEventHandler>();
 
         services.AddHostedService<Launcher>();
         DIHelper.TryAdd<Launcher>();

--- a/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/BulkDownloadIntegrationEventHandler.cs
+++ b/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/BulkDownloadIntegrationEventHandler.cs
@@ -68,7 +68,6 @@ public class BulkDownloadIntegrationEventHandler : IIntegrationEventHandler<Bulk
             var folders = @event.FolderIdsString == null ? new Dictionary<JsonElement, string>() : @event.FolderIdsString.ToDictionary(k => JsonDocument.Parse(k.Key).RootElement, k => k.Value);
             var files = @event.FileIdsString == null ? new Dictionary<JsonElement, string>() : @event.FileIdsString.ToDictionary(k => JsonDocument.Parse(k.Key).RootElement, k => k.Value);
 
-
             await _fileStorageService.BulkDownloadAsync(folders, files);
         }
 

--- a/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/DeleteIntegrationEventHandler.cs
+++ b/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/DeleteIntegrationEventHandler.cs
@@ -1,0 +1,81 @@
+﻿// (c) Copyright Ascensio System SIA 2010-2022
+//
+// This program is a free software product.
+// You can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License (AGPL) version 3 as published by the Free Software
+// Foundation. In accordance with Section 7(a) of the GNU AGPL its Section 15 shall be amended
+// to the effect that Ascensio System SIA expressly excludes the warranty of non-infringement of
+// any third-party rights.
+//
+// This program is distributed WITHOUT ANY WARRANTY, without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For details, see
+// the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+//
+// You can contact Ascensio System SIA at Lubanas st. 125a-25, Riga, Latvia, EU, LV-1021.
+//
+// The  interactive user interfaces in modified source and object code versions of the Program must
+// display Appropriate Legal Notices, as required under Section 5 of the GNU AGPL version 3.
+//
+// Pursuant to Section 7(b) of the License you must retain the original Product logo when
+// distributing the program. Pursuant to Section 7(e) we decline to grant you any rights under
+// trademark law for use of our trademarks.
+//
+// All the Product's GUI elements, including illustrations and icon sets, as well as technical writing
+// content are licensed under the terms of the Creative Commons Attribution-ShareAlike 4.0
+// International. See the License terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+
+using ASC.Core;
+using ASC.Core.Billing;
+using ASC.Web.Files.Services.WCFService;
+
+using Google.Protobuf;
+
+namespace ASC.Thumbnail.IntegrationEvents.EventHandling;
+
+[Scope]
+public class DeleteIntegrationEventHandler : IIntegrationEventHandler<DeleteIntegrationEvent>
+{
+    private readonly ILogger _logger;
+    private readonly FileStorageService _fileStorageService;
+    private readonly SecurityContext _securityContext;
+    private readonly TenantManager _tenantManager;
+    private readonly AuthManager _authManager;
+    private DeleteIntegrationEventHandler() : base()
+    {
+
+    }
+
+    public DeleteIntegrationEventHandler(
+        ILogger<DeleteIntegrationEventHandler> logger,
+        FileStorageService fileStorageService,
+        TenantManager tenantManager,
+        SecurityContext securityContext,
+        AuthManager authManager)
+    {
+        _logger = logger;
+        _authManager = authManager;
+        _fileStorageService = fileStorageService;
+        _securityContext = securityContext;
+        _tenantManager = tenantManager;
+        _securityContext = securityContext;
+        _authManager = authManager;
+    }
+
+
+    public async Task Handle(DeleteIntegrationEvent @event)
+    {
+        CustomSynchronizationContext.CreateContext();
+        using (_logger.BeginScope(new[] { new KeyValuePair<string, object>("integrationEventContext", $"{@event.Id}-{Program.AppName}") }))
+        {
+            _logger.InformationHandlingIntegrationEvent(@event.Id, Program.AppName, @event);
+            await _tenantManager.SetCurrentTenantAsync(@event.TenantId);
+            await _securityContext.AuthenticateMeWithoutCookieAsync(await _authManager.GetAccountByIDAsync(@event.TenantId, @event.CreateBy));
+
+            await _fileStorageService.DeleteItemsAsync("delete", @event.FileIdsString, @event.FolderIdsString, @event.FileIds, @event.FolderIds, false, @event.DeleteAfter, @event.Immediately);
+            await Task.CompletedTask;
+
+        }
+
+    }
+}
+

--- a/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/DeleteIntegrationEventHandler.cs
+++ b/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/DeleteIntegrationEventHandler.cs
@@ -24,12 +24,6 @@
 // content are licensed under the terms of the Creative Commons Attribution-ShareAlike 4.0
 // International. See the License terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
 
-using ASC.Core;
-using ASC.Core.Billing;
-using ASC.Web.Files.Services.WCFService;
-
-using Google.Protobuf;
-
 namespace ASC.Thumbnail.IntegrationEvents.EventHandling;
 
 [Scope]
@@ -71,9 +65,24 @@ public class DeleteIntegrationEventHandler : IIntegrationEventHandler<DeleteInte
             await _tenantManager.SetCurrentTenantAsync(@event.TenantId);
             await _securityContext.AuthenticateMeWithoutCookieAsync(await _authManager.GetAccountByIDAsync(@event.TenantId, @event.CreateBy));
 
-            await _fileStorageService.DeleteItemsAsync("delete", @event.FileIdsString, @event.FolderIdsString, @event.FileIds, @event.FolderIds, false, @event.DeleteAfter, @event.Immediately);
-            await Task.CompletedTask;
+            var files = new List<JsonElement>();
+            var folders = new List<JsonElement>();
+            if (@event.FileIdsString != null)
+            {
+                foreach (var file in @event.FileIdsString)
+                {
+                    files.Add(JsonDocument.Parse(file).RootElement);
+                }
+            }
+            if (@event.FolderIdsString != null)
+            {
+                foreach (var folder in @event.FolderIdsString)
+                {
+                    folders.Add(JsonDocument.Parse(folder).RootElement);
+                }
+            }
 
+            await _fileStorageService.DeleteItemsAsync("delete", files, folders, false, @event.DeleteAfter, @event.Immediately);
         }
 
     }

--- a/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/EmptyTrashIntegrationEventHandler.cs
+++ b/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/EmptyTrashIntegrationEventHandler.cs
@@ -27,20 +27,20 @@
 namespace ASC.Thumbnail.IntegrationEvents.EventHandling;
 
 [Scope]
-public class DeleteIntegrationEventHandler : IIntegrationEventHandler<DeleteIntegrationEvent>
+public class EmptyTrashIntegrationEventHandler : IIntegrationEventHandler<EmptyTrashIntegrationEvent>
 {
     private readonly ILogger _logger;
     private readonly FileStorageService _fileStorageService;
     private readonly SecurityContext _securityContext;
     private readonly TenantManager _tenantManager;
     private readonly AuthManager _authManager;
-    private DeleteIntegrationEventHandler() : base()
+    private EmptyTrashIntegrationEventHandler() : base()
     {
 
     }
 
-    public DeleteIntegrationEventHandler(
-        ILogger<DeleteIntegrationEventHandler> logger,
+    public EmptyTrashIntegrationEventHandler(
+        ILogger<EmptyTrashIntegrationEventHandler> logger,
         FileStorageService fileStorageService,
         TenantManager tenantManager,
         SecurityContext securityContext,
@@ -56,7 +56,7 @@ public class DeleteIntegrationEventHandler : IIntegrationEventHandler<DeleteInte
     }
 
 
-    public async Task Handle(DeleteIntegrationEvent @event)
+    public async Task Handle(EmptyTrashIntegrationEvent @event)
     {
         CustomSynchronizationContext.CreateContext();
         using (_logger.BeginScope(new[] { new KeyValuePair<string, object>("integrationEventContext", $"{@event.Id}-{Program.AppName}") }))
@@ -65,7 +65,7 @@ public class DeleteIntegrationEventHandler : IIntegrationEventHandler<DeleteInte
             await _tenantManager.SetCurrentTenantAsync(@event.TenantId);
             await _securityContext.AuthenticateMeWithoutCookieAsync(await _authManager.GetAccountByIDAsync(@event.TenantId, @event.CreateBy));
 
-            await _fileStorageService.DeleteItemsAsync("delete", @event.FolderIdsString, @event.FileIdsString, @event.FolderIdsInt, @event.FileIdsInt, false, @event.DeleteAfter, @event.Immediately);
+            await _fileStorageService.EmptyTrashAsync();
         }
 
     }

--- a/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/MarkAsReadIntegrationEventHandler.cs
+++ b/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/MarkAsReadIntegrationEventHandler.cs
@@ -27,20 +27,20 @@
 namespace ASC.Thumbnail.IntegrationEvents.EventHandling;
 
 [Scope]
-public class DeleteIntegrationEventHandler : IIntegrationEventHandler<DeleteIntegrationEvent>
+public class MarkAsReadIntegrationEventHandler : IIntegrationEventHandler<MarkAsReadIntegrationEvent>
 {
     private readonly ILogger _logger;
     private readonly FileStorageService _fileStorageService;
     private readonly SecurityContext _securityContext;
     private readonly TenantManager _tenantManager;
     private readonly AuthManager _authManager;
-    private DeleteIntegrationEventHandler() : base()
+    private MarkAsReadIntegrationEventHandler() : base()
     {
 
     }
 
-    public DeleteIntegrationEventHandler(
-        ILogger<DeleteIntegrationEventHandler> logger,
+    public MarkAsReadIntegrationEventHandler(
+        ILogger<MarkAsReadIntegrationEventHandler> logger,
         FileStorageService fileStorageService,
         TenantManager tenantManager,
         SecurityContext securityContext,
@@ -56,7 +56,7 @@ public class DeleteIntegrationEventHandler : IIntegrationEventHandler<DeleteInte
     }
 
 
-    public async Task Handle(DeleteIntegrationEvent @event)
+    public async Task Handle(MarkAsReadIntegrationEvent @event)
     {
         CustomSynchronizationContext.CreateContext();
         using (_logger.BeginScope(new[] { new KeyValuePair<string, object>("integrationEventContext", $"{@event.Id}-{Program.AppName}") }))
@@ -65,7 +65,7 @@ public class DeleteIntegrationEventHandler : IIntegrationEventHandler<DeleteInte
             await _tenantManager.SetCurrentTenantAsync(@event.TenantId);
             await _securityContext.AuthenticateMeWithoutCookieAsync(await _authManager.GetAccountByIDAsync(@event.TenantId, @event.CreateBy));
 
-            await _fileStorageService.DeleteItemsAsync("delete", @event.FolderIdsString, @event.FileIdsString, @event.FolderIdsInt, @event.FileIdsInt, false, @event.DeleteAfter, @event.Immediately);
+            await _fileStorageService.MarkAsReadAsync(@event.FileIdsString, @event.FileIdsString, @event.FolderIdsInt, @event.FileIdsInt);
         }
 
     }

--- a/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/MoveOrCopyIntegrationEventHandler.cs
+++ b/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/MoveOrCopyIntegrationEventHandler.cs
@@ -64,23 +64,8 @@ public class MoveOrCopyIntegrationEventHandler : IIntegrationEventHandler<MoveOr
             _logger.InformationHandlingIntegrationEvent(@event.Id, Program.AppName, @event);
             await _tenantManager.SetCurrentTenantAsync(@event.TenantId);
             await _securityContext.AuthenticateMeWithoutCookieAsync(await _authManager.GetAccountByIDAsync(@event.TenantId, @event.CreateBy));
-            var files = new List<JsonElement>();
-            var folders = new List<JsonElement>();
-            if (@event.FileIdsString != null)
-            {
-                foreach (var file in @event.FileIdsString)
-                {
-                    files.Add(JsonDocument.Parse(file).RootElement);
-                }
-            }
-            if(@event.FolderIdsString != null)
-            {
-                foreach (var folder in @event.FolderIdsString)
-                {
-                    folders.Add(JsonDocument.Parse(folder).RootElement);
-                }
-            }
-            await _fileStorageService.MoveOrCopyItemsAsync(folders, files, JsonDocument.Parse(@event.DestFolderId).RootElement, @event.ConflictResolveType, @event.Ic, @event.DeleteAfter, @event.Content);
+            
+            await _fileStorageService.MoveOrCopyItemsAsync(@event.FolderIdsString, @event.FileIdsString, @event.FolderIdsInt, @event.FileIdsInt, JsonDocument.Parse(@event.DestFolderId).RootElement, @event.ConflictResolveType, @event.Ic, @event.DeleteAfter, @event.Content);
         }
 
     }

--- a/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/MoveOrCopyIntegrationEventHandler.cs
+++ b/products/ASC.Files/Service/Thumbnail/IntegrationEvents/EventHandling/MoveOrCopyIntegrationEventHandler.cs
@@ -1,0 +1,85 @@
+﻿// (c) Copyright Ascensio System SIA 2010-2022
+//
+// This program is a free software product.
+// You can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License (AGPL) version 3 as published by the Free Software
+// Foundation. In accordance with Section 7(a) of the GNU AGPL its Section 15 shall be amended
+// to the effect that Ascensio System SIA expressly excludes the warranty of non-infringement of
+// any third-party rights.
+//
+// This program is distributed WITHOUT ANY WARRANTY, without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For details, see
+// the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+//
+// You can contact Ascensio System SIA at Lubanas st. 125a-25, Riga, Latvia, EU, LV-1021.
+//
+// The  interactive user interfaces in modified source and object code versions of the Program must
+// display Appropriate Legal Notices, as required under Section 5 of the GNU AGPL version 3.
+//
+// Pursuant to Section 7(b) of the License you must retain the original Product logo when
+// distributing the program. Pursuant to Section 7(e) we decline to grant you any rights under
+// trademark law for use of our trademarks.
+//
+// All the Product's GUI elements, including illustrations and icon sets, as well as technical writing
+// content are licensed under the terms of the Creative Commons Attribution-ShareAlike 4.0
+// International. See the License terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+
+using ASC.Core;
+using ASC.Core.Billing;
+using ASC.Web.Files.Services.WCFService;
+
+using Google.Protobuf;
+
+using Tweetinvi.Core.Events;
+
+namespace ASC.Thumbnail.IntegrationEvents.EventHandling;
+
+[Scope]
+public class MoveOrCopyIntegrationEventHandler : IIntegrationEventHandler<MoveOrCopyIntegrationEvent>
+{
+    private readonly ILogger _logger;
+    private readonly FileStorageService _fileStorageService;
+    private readonly SecurityContext _securityContext;
+    private readonly TenantManager _tenantManager;
+    private readonly AuthManager _authManager;
+    private MoveOrCopyIntegrationEventHandler() : base()
+    {
+
+    }
+
+    public MoveOrCopyIntegrationEventHandler(
+        ILogger<MoveOrCopyIntegrationEventHandler> logger,
+        FileStorageService fileStorageService,
+        TenantManager tenantManager,
+        SecurityContext securityContext,
+        AuthManager authManager)
+    {
+        _logger = logger;
+        _authManager = authManager;
+        _fileStorageService = fileStorageService;
+        _securityContext = securityContext;
+        _tenantManager = tenantManager;
+        _securityContext = securityContext;
+        _authManager = authManager;
+    }
+
+
+    public async Task Handle(MoveOrCopyIntegrationEvent @event)
+    {
+        CustomSynchronizationContext.CreateContext();
+        using (_logger.BeginScope(new[] { new KeyValuePair<string, object>("integrationEventContext", $"{@event.Id}-{Program.AppName}") }))
+        {
+            _logger.InformationHandlingIntegrationEvent(@event.Id, Program.AppName, @event);
+            var tets = JsonDocument.Parse(@event.DestFolderId).RootElement;
+            await _tenantManager.SetCurrentTenantAsync(@event.TenantId);
+            await _securityContext.AuthenticateMeWithoutCookieAsync(await _authManager.GetAccountByIDAsync(@event.TenantId, @event.CreateBy));
+
+            await _fileStorageService.MoveOrCopyItemsAsync(@event.FileIdsString, @event.FolderIdsString, @event.FileIds, @event.FolderIds, JsonDocument.Parse(@event.DestFolderId).RootElement, @event.ConflictResolveType, @event.Ic, @event.DeleteAfter, @event.Content);
+           
+            await Task.CompletedTask;
+
+        }
+
+    }
+}
+


### PR DESCRIPTION
Transfered long operations to ASC.Files.Service such as: 
- fileops/emptytrash
- fileops/move
- fileops/markasread
- fileops/delete
- fileops/copy
- fileops/bulkdownload
Added IntegrationEvents: BulkDownloadIntegrationEvent, DeleteIntegrationEvent, EmptyTrashIntegrationEvent, MoveOrCopyIntegrationEvent, MarkAsReadIntegrationEvent
Added IntegrationEventsHandler: BulkDownloadIntegrationEventHandler, DeleteIntegrationEventHandler, EmptyTrashIntegrationEventHandler, MoveOrCopyIntegrationEventHandler, MarkAsReadIntegrationEventHandler