### PR TITLE
Bugfix/fixed notify exception

### DIFF
--- a/web/ASC.Web.Core/Notify/StudioNotifyServiceSender.cs
+++ b/web/ASC.Web.Core/Notify/StudioNotifyServiceSender.cs
@@ -165,7 +165,7 @@ public class StudioNotifyWorker
             item.Recipients?.Select(r => r.IsGroup ? new RecipientsGroup(r.Id, r.Name) : (IRecipient)new DirectRecipient(r.Id, r.Name, r.Addresses?.ToArray(), r.CheckActivation)).ToArray(),
             item.SenderNames != null && item.SenderNames.Count > 0 ? item.SenderNames.ToArray() : null,
             item.CheckSubsciption,
-            item.Tags.Select(r => new TagValue(r.Key, r.Value)).ToArray());
+            item.Tags?.Select(r => new TagValue(r.Key, r.Value)).ToArray());
     }
 }
 


### PR DESCRIPTION
ASC.Web.Core: Notify: fixed ArgumentNullException: Value cannot be null. (Parameter 'source')