### PR TITLE
Bugfix/error from notify log

### DIFF
--- a/web/ASC.Web.Core/Notify/StudioNotifyService.cs
+++ b/web/ASC.Web.Core/Notify/StudioNotifyService.cs
@@ -172,6 +172,7 @@ public class StudioNotifyService
                     await _studioNotifyHelper.RecipientFromEmailAsync(email, false),
                 new[] { EMailSenderName },
                 new TagValue(Tags.InviteLink, confirmationUrl),
+                new TagValue(CommonTags.Culture, user.GetCulture().Name),
                 TagValues.OrangeButton(orangeButtonText, confirmationUrl),
                     new TagValue(Tags.UserDisplayName, (user.DisplayUserName(_displayUserSettingsHelper) ?? string.Empty).Trim()));
     }


### PR DESCRIPTION
ASC.Web.Core: StudioNotifyService: fix error in notify logs

System.Exception: Could not resolve current tenant :-(.
   at ASC.Core.TenantManager.GetCurrentTenant(Boolean throwIfNotFound, HttpContext context)
   at ASC.Core.TenantManager.GetCurrentTenant(Boolean throwIfNotFound)
   at ASC.Core.UserManager.get_Tenant()
   at ASC.Core.UserManager.GetUserByEmailAsync(String email)
   at ASC.Core.UserManager.SearchUserAsync(String id)
   at ASC.Notify.Engine.NotifyRequest.GetCulture(TenantManager tenantManager, UserManager userManager)
   at ASC.Core.Notify.NotifySource.GetPatternProvider(NotifyRequest r)
   at ASC.Notify.Engine.NotifyRequest.GetPatternProvider(IServiceScope scope)
   at ASC.Notify.Engine.NotifyEngine.PrepareRequestFillPatterns(NotifyRequest request, IServiceScope serviceScope)
   at ASC.Notify.Engine.NotifyEngine.SendDirectNotifyAsync(NotifyRequest request, IServiceScope serviceScope)