### PR TITLE
Bugfix/error from notify log2

### DIFF
--- a/products/ASC.Files/Core/Core/FileStorageService.cs
+++ b/products/ASC.Files/Core/Core/FileStorageService.cs
@@ -1221,7 +1221,7 @@ public class FileStorageService //: IFileStorageService
 
         comment = await fileDao.UpdateCommentAsync(fileId, version, comment);
 
-        await _filesMessageService.SendAsync(MessageAction.FileUpdatedRevisionComment, file, file.Title, version.ToString(CultureInfo.InvariantCulture));
+        await _filesMessageService.SendAsync(MessageAction.FileUpdatedRevisionComment, file, new[] { file.Title, version.ToString(CultureInfo.InvariantCulture) });
 
         return comment;
     }

--- a/web/ASC.Web.Core/IProduct.cs
+++ b/web/ASC.Web.Core/IProduct.cs
@@ -38,5 +38,5 @@ public interface IProduct : IWebItem
 
     void Shutdown();
 
-    Task<IEnumerable<ActivityInfo>> GetAuditEventsAsync(DateTime scheduleDate, Guid userId, Tenant tenant,WhatsNewType whatsNewType);
+    Task<IEnumerable<ActivityInfo>> GetAuditEventsAsync(DateTime scheduleDate, Guid userId, Tenant tenant,WhatsNewType whatsNewType, ILogger logger);
 }

--- a/web/ASC.Web.Core/Notify/StudioWhatsNewNotify.cs
+++ b/web/ASC.Web.Core/Notify/StudioWhatsNewNotify.cs
@@ -176,7 +176,7 @@ public class StudioWhatsNewNotify
 
                 foreach (var p in products)
                 {
-                    auditEvents.AddRange(await p.GetAuditEventsAsync(scheduleDate, user.Id, tenant, whatsNewType));
+                    auditEvents.AddRange(await p.GetAuditEventsAsync(scheduleDate, user.Id, tenant, whatsNewType, _log));
                 }
 
                 _log.Debug($"SendMsgWhatsNew auditEvents count : {auditEvents.Count}");//temp

--- a/web/ASC.Web.Core/Product.cs
+++ b/web/ASC.Web.Core/Product.cs
@@ -49,7 +49,7 @@ public abstract class Product : IProduct
 
     public virtual void Shutdown() { }
 
-    public virtual Task<IEnumerable<ActivityInfo>> GetAuditEventsAsync(DateTime scheduleDate, Guid userId, Tenant tenant, WhatsNewType whatsNewType)
+    public virtual Task<IEnumerable<ActivityInfo>> GetAuditEventsAsync(DateTime scheduleDate, Guid userId, Tenant tenant, WhatsNewType whatsNewType, ILogger logger)
     {
         return Task.FromResult(Enumerable.Empty<ActivityInfo>());
     }


### PR DESCRIPTION
ASC.Web.Core: StudioWhatsNewNotify: fix error in notify logs (FileUpdatedRevisionComment audit event is written to the database without room information)

System.Text.Json.JsonException: The JSON value could not be converted to ASC.MessagingSystem.Core.AdditionalNotificationInfo. Path: $ | LineNumber: 0 | BytePositionInLine: 1.
   at System.Text.Json.ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 utf8Json, JsonTypeInfo jsonTypeInfo, Nullable`1 actualByteCount)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 json, JsonTypeInfo jsonTypeInfo)
   at ASC.Web.Files.Configuration.ProductEntryPoint.GetAuditEventsAsync(DateTime scheduleDate, Guid userId, Tenant tenant, WhatsNewType whatsNewType) in /app/onlyoffice/src/server/products/ASC.Files/Core/Configuration/ProductEntryPoint.cs:line 262
   at ASC.Web.Studio.Core.Notify.StudioWhatsNewNotify.SendMsgWhatsNewAsync(Int32 tenantid, DateTime scheduleDate, WhatsNewType whatsNewType, List`1 products)