### PR TITLE
Bugfix/error from notify log4

### DIFF
--- a/common/ASC.Core.Common/GeolocationHelper.cs
+++ b/common/ASC.Core.Common/GeolocationHelper.cs
@@ -67,6 +67,10 @@ public class GeolocationHelper
     {
         try
         {
+            if (string.IsNullOrEmpty(ip))
+            {
+                return new[] { string.Empty, string.Empty };
+            }
             var location = await GetIPGeolocationAsync(IPAddress.Parse(ip));
             if (string.IsNullOrEmpty(location.Key) || (location.Key == "ZZ"))
             {


### PR DESCRIPTION
ASC.Core.Common: GeolocationHelper: added check for null before parsing IP

System.ArgumentNullException: Value cannot be null. (Parameter 'ipString')
   at System.ArgumentNullException.Throw(String paramName)
   at System.Net.IPAddress.Parse(String ipString)
   at ASC.Geolocation.GeolocationHelper.GetGeolocationAsync(String ip)