### PR TITLE
Bugfix/error from notify log5

### DIFF
--- a/common/ASC.MessagingSystem/Core/MessageSettings.cs
+++ b/common/ASC.MessagingSystem/Core/MessageSettings.cs
@@ -67,7 +67,7 @@ public class MessageSettings
 
     public static string GetIP(HttpRequest request)
     {
-        return request.HttpContext.Connection.RemoteIpAddress?.ToString();
+        return request?.HttpContext?.Connection.RemoteIpAddress?.ToString();
     }
 
     public static void AddInfoMessage(EventMessage message, Dictionary<string, ClientInfo> dict = null)


### PR DESCRIPTION
ASC.MessagingSystem: MessageSettings: added check for null before getting IP (Error while parse Http Request for FileConverted type of event)

action	FileConverted
applicationContext	FilesService
exception	System.NullReferenceException: Object reference not set to an instance of an object.
   at ASC.MessagingSystem.MessageSettings.GetIP(HttpRequest request)
   at ASC.MessagingSystem.Core.MessageFactory.CreateAsync(HttpRequest request, String initiator, Nullable`1 dateTime, MessageAction action, MessageTarget target, String[] description)