### PR TITLE
Feature/notify dbworker fix

### DIFF
--- a/common/services/ASC.Notify/DbWorker.cs
+++ b/common/services/ASC.Notify/DbWorker.cs
@@ -43,7 +43,8 @@ public class DbWorker(IServiceScopeFactory serviceScopeFactory, IOptions<NotifyS
 
         await strategy.ExecuteAsync(async () =>
         {
-            await using var tx = await dbContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+            await using var dbContext = await scope.ServiceProvider.GetService<IDbContextFactory<NotifyDbContext>>().CreateDbContextAsync();
+            await using var tx = await dbContext.Database.BeginTransactionAsync();
             var notifyQueue = mapper.Map<NotifyMessage, NotifyQueue>(m);
             notifyQueue.Attachments = JsonConvert.SerializeObject(m.Attachments);
 

--- a/common/services/ASC.Notify/DbWorker.cs
+++ b/common/services/ASC.Notify/DbWorker.cs
@@ -37,9 +37,9 @@ public class DbWorker(IServiceScopeFactory serviceScopeFactory, IOptions<NotifyS
 
         var mapper = scope.ServiceProvider.GetRequiredService<IMapper>();
 
-        await using var ñontext = await scope.ServiceProvider.GetService<IDbContextFactory<NotifyDbContext>>().CreateDbContextAsync();
+        await using var context = await scope.ServiceProvider.GetService<IDbContextFactory<NotifyDbContext>>().CreateDbContextAsync();
 
-        var strategy = ñontext.Database.CreateExecutionStrategy();
+        var strategy = context.Database.CreateExecutionStrategy();
 
         await strategy.ExecuteAsync(async () =>
         {

--- a/common/services/ASC.Notify/DbWorker.cs
+++ b/common/services/ASC.Notify/DbWorker.cs
@@ -37,9 +37,9 @@ public class DbWorker(IServiceScopeFactory serviceScopeFactory, IOptions<NotifyS
 
         var mapper = scope.ServiceProvider.GetRequiredService<IMapper>();
 
-        await using var dbContext = await scope.ServiceProvider.GetService<IDbContextFactory<NotifyDbContext>>().CreateDbContextAsync();
+        await using var ñontext = await scope.ServiceProvider.GetService<IDbContextFactory<NotifyDbContext>>().CreateDbContextAsync();
 
-        var strategy = dbContext.Database.CreateExecutionStrategy();
+        var strategy = ñontext.Database.CreateExecutionStrategy();
 
         await strategy.ExecuteAsync(async () =>
         {


### PR DESCRIPTION
ASC.Notify: DbWorker: using own dbcontext and default isolation level for transaction inside execution strategy

errors in the log file:

Microsoft.EntityFrameworkCore.DbUpdateException: An error occurred while saving the entity changes. See the inner exception for details. ---> MySqlConnector.MySqlException (0x80004005): Duplicate entry '[some id]' for key 'notify_info.PRIMARY'