### PR TITLE
Bugfix/66512

### DIFF
--- a/common/ASC.Core.Common/Tenants/TenantDomainValidator.cs
+++ b/common/ASC.Core.Common/Tenants/TenantDomainValidator.cs
@@ -38,7 +38,7 @@ public class TenantDomainValidator
 
     public TenantDomainValidator(IConfiguration configuration, CoreBaseSettings coreBaseSettings)
     {
-        MaxLength = 100;
+        MaxLength = 63;
 
         if (int.TryParse(configuration["web:alias:max"], out var defaultMaxLength))
         {


### PR DESCRIPTION
fix Bug 66512

A subdomain can be up to 255 characters long, but if you have multiple levels in your subdomain, each level can only be 63 characters long.