### PR TITLE
Bugfix/room deletion

### DIFF
--- a/products/ASC.Files/Service/GlobalUsings.cs
+++ b/products/ASC.Files/Service/GlobalUsings.cs
@@ -82,6 +82,7 @@ global using ASC.Web.Files.Services.FFmpegService;
 global using ASC.Web.Files.Services.WCFService;
 global using ASC.Web.Files.Utils;
 global using ASC.Web.Studio.Core;
+global using ASC.Web.Studio.Core.Notify;
 global using ASC.Web.Studio.Utility;
 
 global using Autofac;

--- a/products/ASC.Files/Service/Startup.cs
+++ b/products/ASC.Files/Service/Startup.cs
@@ -104,6 +104,7 @@ public class Startup : BaseWorkerStartup
         DIHelper.TryAdd<DistributedTaskProgress>();
         DIHelper.TryAdd<DocumentBuilderTask<int>>();
         DIHelper.TryAdd<AdditionalWhiteLabelSettingsHelperInit>();
+        DIHelper.TryAdd<NotifyConfiguration>();
 
         services.AddScoped<ITenantQuotaFeatureChecker, CountRoomChecker>();
         services.AddScoped<CountRoomChecker>();


### PR DESCRIPTION
The dependency container lacked a service necessary for sending notification about room deletion, which resulted in NullReferencEexception