### PR TITLE
Bugfix/trash cleaner context

### DIFF
--- a/common/ASC.Core.Common/Context/CustomSynchronizationContext.cs
+++ b/common/ASC.Core.Common/Context/CustomSynchronizationContext.cs
@@ -35,9 +35,9 @@ public class CustomSynchronizationContext
     private static readonly AsyncLocal<CustomSynchronizationContext> _context = new();
     public static CustomSynchronizationContext CurrentContext => _context.Value;
 
-    public static void CreateContext()
+    public static void CreateContext(bool force = false)
     {
-        if (CurrentContext == null)
+        if (CurrentContext == null || force)
         {
             var context = new CustomSynchronizationContext();
             _context.Value = context;

--- a/products/ASC.Files/Service/Cleanup/Worker.cs
+++ b/products/ASC.Files/Service/Cleanup/Worker.cs
@@ -69,6 +69,8 @@ public class Worker(ILogger<Worker> logger, IServiceScopeFactory serviceScopeFac
 
         try
         {
+            CustomSynchronizationContext.CreateContext(true);
+
             await using var scope = serviceScopeFactory.CreateAsyncScope();
             var tenantManager = scope.ServiceProvider.GetRequiredService<TenantManager>();
             await tenantManager.SetCurrentTenantAsync(tenantUser.TenantId);


### PR DESCRIPTION
Сreating a unique CustomSynchronizationContext in each task

reason:
System.Security.Authentication.InvalidCredentialException: account   at ASC.Core.SecurityContext.AuthenticateMeWithoutCookieAsync(IAccount account, List`1 additionalClaims, Guid session)   at ASC.Thumbnail.IntegrationEvents.EventHandling.DeleteIntegrationEventHandler.Handle(DeleteIntegrationEvent event)
