### PR TITLE
Update TariffService to create default value on null

### DIFF
--- a/common/ASC.Core.Common/Billing/TariffService.cs
+++ b/common/ASC.Core.Common/Billing/TariffService.cs
@@ -582,7 +582,7 @@ public class TariffService(
 
         if (r == null)
         {
-            return null;
+            return await CreateDefaultAsync();
         }
 
         var tariff = await CreateDefaultAsync(true);

--- a/common/ASC.Core.Common/Billing/TariffService.cs
+++ b/common/ASC.Core.Common/Billing/TariffService.cs
@@ -787,7 +787,6 @@ public class TariffService(
             DueDate = DateTime.MaxValue,
             DelayDueDate = DateTime.MaxValue,
             LicenseDate = DateTime.MaxValue,
-            CustomerId = "",
             Quotas = []
         };
 


### PR DESCRIPTION
Changed the behavior of the TariffService. Instead of returning null, it now asynchronously creates a default value if there's no result. This ensures the process never returns a null, improving reliability.