### PR TITLE
Feature/linkutility origin header

### DIFF
--- a/common/ASC.Core.Common/BaseCommonLinkUtility.cs
+++ b/common/ASC.Core.Common/BaseCommonLinkUtility.cs
@@ -105,7 +105,9 @@ public class BaseCommonLinkUtility
             // first, take from current request
             if (_httpContextAccessor?.HttpContext?.Request != null && !serverUriForce)
             {
-                var u = _httpContextAccessor?.HttpContext?.Request.Url();
+                var origin = _httpContextAccessor.HttpContext.Request.Headers[HeaderNames.Origin].FirstOrDefault();
+
+                var u = string.IsNullOrEmpty(origin) ? _httpContextAccessor.HttpContext.Request.Url() : new Uri(origin);
 
                 ArgumentNullException.ThrowIfNull(u);
 


### PR DESCRIPTION
BaseCommonLinkUtility: use the header "original" when forming links if such is passed