### PR TITLE
Refactor Notify Service configuration and log usage

### DIFF
--- a/common/services/ASC.Notify/Config/NotifyServiceCfg.cs
+++ b/common/services/ASC.Notify/Config/NotifyServiceCfg.cs
@@ -41,14 +41,12 @@ public class ConfigureNotifyServiceCfg
         {
             try
             {        
-                var sender = (INotifySender)serviceProvider.GetService(System.Type.GetType(s.Type, true));
+                var sender = (INotifySender)serviceProvider.GetService(Type.GetType(s.Type, true));
                 if (sender != null)
                 {
                     sender.Init(s.Properties);
                     s.NotifySender = sender;
                 }
-
-                s.Init(serviceProvider);
             }
             catch (Exception)
             {
@@ -104,13 +102,6 @@ public class NotifyServiceCfgSender
     public string Type { get; set; }
     public Dictionary<string, string> Properties { get; set; }
     public INotifySender NotifySender { get; set; }
-
-    public void Init(IServiceProvider serviceProvider)
-    {
-        var sender = (INotifySender)serviceProvider.GetService(System.Type.GetType(Type, true));
-        sender.Init(Properties);
-        NotifySender = sender;
-    }
 }
 
 public class NotifyServiceCfgScheduler

--- a/common/services/ASC.Notify/DbWorker.cs
+++ b/common/services/ASC.Notify/DbWorker.cs
@@ -27,7 +27,7 @@
 namespace ASC.Notify;
 
 [Singleton]
-public class DbWorker(IServiceScopeFactory serviceScopeFactory, IOptions<NotifyServiceCfg> notifyServiceCfg, IDistributedLockProvider distributedLockProvider)
+public class DbWorker(IServiceScopeFactory serviceScopeFactory, ConfigureNotifyServiceCfg notifyServiceCfg, IDistributedLockProvider distributedLockProvider)
 {
     private readonly NotifyServiceCfg _notifyServiceCfg = notifyServiceCfg.Value;
 

--- a/common/services/ASC.Notify/Services/NotifyCleanerService.cs
+++ b/common/services/ASC.Notify/Services/NotifyCleanerService.cs
@@ -27,13 +27,13 @@
 namespace ASC.Notify.Services;
 
 [Singleton]
-public class NotifyCleanerService(IOptions<NotifyServiceCfg> notifyServiceCfg, 
-                                  IServiceScopeFactory scopeFactory,
-                                  ILogger<NotifyCleanerService> logger) : ActivePassiveBackgroundService<NotifyCleanerService>(logger, scopeFactory)
+public class NotifyCleanerService(
+    ConfigureNotifyServiceCfg notifyServiceCfg, 
+    IServiceScopeFactory scopeFactory,
+    ILogger<NotifyCleanerService> logger) : ActivePassiveBackgroundService<NotifyCleanerService>(logger, scopeFactory)
 
 {
     private readonly IServiceScopeFactory _serviceScopeFactory = scopeFactory;
-    private readonly ILogger<NotifyCleanerService> _logger = logger;
     private readonly NotifyServiceCfg _notifyServiceCfg = notifyServiceCfg.Value;
 
     protected override TimeSpan ExecuteTaskPeriod { get; set; } = TimeSpan.FromMilliseconds(1000);
@@ -57,7 +57,7 @@ public class NotifyCleanerService(IOptions<NotifyServiceCfg> notifyServiceCfg,
          }
          catch (Exception err)
          {
-             _logger.ErrorClear(err);
+             logger.ErrorClear(err);
          }
     }
 }

--- a/common/services/ASC.Notify/Startup.cs
+++ b/common/services/ASC.Notify/Startup.cs
@@ -41,9 +41,7 @@ public class Startup : BaseWorkerStartup
     public override async Task ConfigureServices(IServiceCollection services)
     {
         await base.ConfigureServices(services);
-
-        services.Configure<NotifyServiceCfg>(Configuration.GetSection("notify"));
-
+        
         services.AddActivePassiveHostedService<NotifySenderService>(DIHelper, Configuration);
         services.AddActivePassiveHostedService<NotifyCleanerService>(DIHelper, Configuration);
 


### PR DESCRIPTION
The `ConfigureNotifyServiceCfg` class has been refactored to read configuration and initialize Senders and Schedulers directly. This revision also includes cleaner error handling and better log usage. In several services, the constructor now takes an instance of `ConfigureNotifyServiceCfg`, replacing separate `IOptions<NotifyServiceCfg>` and `IServiceProvider` parameters.