### PR TITLE
Bugfix/zoom notify

### DIFF
--- a/web/ASC.Web.Core/Notify/StudioNotifyService.cs
+++ b/web/ASC.Web.Core/Notify/StudioNotifyService.cs
@@ -950,7 +950,7 @@ public class StudioNotifyService(
 
     #region Zoom
 
-    public async Task SendZoomWelcomeAsync(UserInfo u)
+    public async Task SendZoomWelcomeAsync(UserInfo u, string portalUrl = null)
     {
         try
         {
@@ -961,6 +961,7 @@ public class StudioNotifyService(
                 Actions.ZoomWelcome,
                 await studioNotifyHelper.RecipientFromEmailAsync(u.Email, false),
                 [EMailSenderName],
+                portalUrl ??= commonLinkUtility.GetFullAbsolutePath(""),
                 new TagValue(CommonTags.Culture, culture.Name),
                 new TagValue(Tags.UserName, u.FirstName.HtmlEncode()),
                 new TagValue(CommonTags.TopGif, studioNotifyHelper.GetNotificationImageUrl("welcome.gif")),


### PR DESCRIPTION
StudioNotifyService: set basedomain when sending zoom notification (Bug 69433)