### PR TITLE
fix error CS0121 on some dotnet sdk

### DIFF
--- a/common/ASC.Core.Common/Configuration/SmtpSettings.cs
+++ b/common/ASC.Core.Common/Configuration/SmtpSettings.cs
@@ -105,7 +105,7 @@ public class SmtpSettings
             return Empty;
         }
 
-        var props = value.Split(['#'], StringSplitOptions.None);
+        var props = value.Split('#');
         props = Array.ConvertAll(props, p => !string.IsNullOrEmpty(p) ? p : null);
 
         var host = HttpUtility.UrlDecode(props[3]);

--- a/common/ASC.Core.Common/Context/Impl/UserManager.cs
+++ b/common/ASC.Core.Common/Context/Impl/UserManager.cs
@@ -279,7 +279,7 @@ public class UserManager(
             return [];
         }
 
-        var words = text.Split([' '], StringSplitOptions.RemoveEmptyEntries);
+        var words = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (words.Length == 0)
         {
             return [];

--- a/common/ASC.Core.Common/Core/UserInfo.cs
+++ b/common/ASC.Core.Common/Core/UserInfo.cs
@@ -260,7 +260,7 @@ public sealed class UserInfo : IDirectRecipient, ICloneable, IMapFrom<User>
             ContactsList.Clear();
         }
 
-        ContactsList.AddRange(contacts.Split(['|'], StringSplitOptions.RemoveEmptyEntries));
+        ContactsList.AddRange(contacts.Split('|', StringSplitOptions.RemoveEmptyEntries));
 
         return this;
     }

--- a/common/ASC.Core.Common/Encryption/EncryptionSettings.cs
+++ b/common/ASC.Core.Common/Encryption/EncryptionSettings.cs
@@ -101,7 +101,7 @@ public class EncryptionSettingsHelper(CoreConfiguration coreConfiguration, Insta
             return new EncryptionSettings();
         }
 
-        var parts = value.Split(['#'], StringSplitOptions.None);
+        var parts = value.Split('#');
 
         var password = string.IsNullOrEmpty(parts[0]) ? string.Empty : instanceCrypto.Decrypt(parts[0]);
         var status = int.Parse(parts[1]);

--- a/common/ASC.Core.Common/Encryption/EncryptionSettings.cs
+++ b/common/ASC.Core.Common/Encryption/EncryptionSettings.cs
@@ -122,7 +122,7 @@ public class EncryptionSettingsHelper(CoreConfiguration coreConfiguration, Insta
             return new EncryptionSettings();
         }
 
-        var parts = value.Split(['#'], StringSplitOptions.None);
+        var parts = value.Split('#');
 
         var password = string.IsNullOrEmpty(parts[0]) ? string.Empty : await instanceCrypto.DecryptAsync(parts[0]);
         var status = int.Parse(parts[1]);

--- a/common/ASC.Core.Common/Notify/Patterns/NVelocityPatternFormatter.cs
+++ b/common/ASC.Core.Common/Notify/Patterns/NVelocityPatternFormatter.cs
@@ -70,7 +70,7 @@ public sealed class NVelocityPatternFormatter() : PatternFormatter(DefaultPatter
             return;
         }
 
-        var lines = originalString.Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
+        var lines = originalString.Split(["\n", "\r"], StringSplitOptions.RemoveEmptyEntries);
         if (lines.Length == 0)
         {
             return;

--- a/common/ASC.Core.Common/Notify/Senders/SmtpSender.cs
+++ b/common/ASC.Core.Common/Notify/Senders/SmtpSender.cs
@@ -208,7 +208,7 @@ public class SmtpSender(IConfiguration configuration,
 
         mimeMessage.From.Add(fromAddress);
 
-        foreach (var to in m.Reciever.Split(['|'], StringSplitOptions.RemoveEmptyEntries))
+        foreach (var to in m.Reciever.Split('|', StringSplitOptions.RemoveEmptyEntries))
         {
             mimeMessage.To.Add(MailboxAddress.Parse(ParserOptions.Default, to));
         }

--- a/common/ASC.Core.Common/Security/EmailValidationKeyProvider.cs
+++ b/common/ASC.Core.Common/Security/EmailValidationKeyProvider.cs
@@ -136,7 +136,7 @@ public class EmailValidationKeyProvider
         ArgumentNullException.ThrowIfNull(key);
 
         email = FormatEmail(tenantId, email);
-        var parts = key.Split(['.'], StringSplitOptions.RemoveEmptyEntries);
+        var parts = key.Split('.', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length != 2)
         {
             return ValidationResult.Invalid;

--- a/common/ASC.Core.Common/Tenants/Tenant.cs
+++ b/common/ASC.Core.Common/Tenants/Tenant.cs
@@ -128,7 +128,7 @@ public class Tenant : IMapFrom<DbTenant>
         {
             if (_domains.Count == 0 && !string.IsNullOrEmpty(TrustedDomainsRaw))
             {
-                _domains = TrustedDomainsRaw.Split(['|'],
+                _domains = TrustedDomainsRaw.Split('|',
                     StringSplitOptions.RemoveEmptyEntries).ToList();
             }
 


### PR DESCRIPTION
This pull request fixes 
error CS0121: The call is ambiguous between the following methods or properties: 'string.Split(char[]?, StringSplitOptions)' and 'string.Split(string?, StringSplitOptions)'
It is better to use char version of split  '|' instead of string ['|']. splitoptions none is the default value.