### PR TITLE
Add NuGet package source mapping for local packages

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,6 +7,14 @@
     <add key="Custom NuGet Server" value=".nuget\packages" />
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="Custom NuGet Server">
+      <package pattern="SimpleRESTServicesNET60" />
+    </packageSource>
+    <packageSource key="NuGet official package source">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
   <packageRestore>
     <add key="enabled" value="True" />
     <add key="automatic" value="True" />


### PR DESCRIPTION
`SimpleRESTServicesNET60` is provided by the local `.nuget\packages` source but `NuGet.Config` has no `packageSourceMapping`, so NuGet queries all configured sources for it. This adds source mapping to pin `SimpleRESTServicesNET60` to the local feed.